### PR TITLE
fix link to bzip2

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -537,7 +537,7 @@ build_dlfcn() {
 }
 
 build_bzip2() {
-  download_and_unpack_file http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
+  download_and_unpack_file https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz
   cd bzip2-1.0.6
     apply_patch file://$patch_dir/bzip2-1.0.6_brokenstuff.diff
     if [[ ! -f $mingw_w64_x86_64_prefix/lib/libbz2.a ]]; then # Library only.


### PR DESCRIPTION
Update link to download bzip (old link destination now serves an HTML site)