### PR TITLE
fix clone of twolame

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -945,7 +945,7 @@ build_lame() {
 }
 
 build_twolame() {
-  do_git_checkout https://github.com/njh/twolame.git
+  do_git_checkout https://github.com/njh/twolame.git "" main
   cd twolame_git
     if [[ ! -f Makefile.am.bak ]]; then # Library only.
       sed -i.bak "/^SUBDIRS/s/ frontend.*//" Makefile.am


### PR DESCRIPTION
twoname has renamed the branch "master" to "main"